### PR TITLE
CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,16 @@ jobs:
           sudo apt update
           sudo apt install postgresql-12 liblapack-dev liblapacke-dev
 
+      - name: Add conda to system path
+        run: |
+          # $CONDA is an environment variable pointing to the root of the miniconda directory
+          echo $CONDA/bin >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: |
+          conda install --yes -c conda-forge python=${{ matrix.python-version }}
+          conda install --yes -c conda-forge matplotlib-base pyyaml openblas gcc_linux-64 h5py scipy pytest codecov pytest-cov spglib alm
+
       - name: Install python dependencies
         run: |
           pip install --upgrade setuptools wheel


### PR DESCRIPTION
Github action workflow failed because newly added test requires ALM as the external force constants calculator. Now ALM is installed using conda in the workflow.