### PR TITLE
Change behaviour of phonopy workchain without mesh in setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: Continuous Integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches-ignore:
+      - rc
+      - master
+  pull_request:
+    branches: [develop]
 
 jobs:
   pre-commit:

--- a/aiida_phonoxpy/utils/utils.py
+++ b/aiida_phonoxpy/utils/utils.py
@@ -100,8 +100,10 @@ def setup_phonopy_calculation(
         'random_seed' : int, optional
         'is_plusminus' : str or bool, optional
         'is_diagonal' : bool, optional
-        'mesh' : float or list, optional
+        'mesh' : float, list, optional
             Mesh numbers or distance measure of q-point sampling mesh.
+            If this key is unavailable, only force constants are calculated
+            from given displacements and forces.
         'fc_calculator' : str, optional
             External force constants calculator.
         'fc_calculator_options' : str, optional
@@ -137,8 +139,8 @@ def setup_phonopy_calculation(
         for key in valid_keys:
             if key in phonon_settings.keys():
                 ph_settings[key] = phonon_settings[key]
-        if "mesh" not in ph_settings:
-            ph_settings["mesh"] = 100.0
+        # if "mesh" not in ph_settings:
+        #     ph_settings["mesh"] = 100.0
 
     return_vals = {}
     if "supercell_matrix" in phonon_settings:

--- a/aiida_phonoxpy/workflows/phonopy.py
+++ b/aiida_phonoxpy/workflows/phonopy.py
@@ -89,7 +89,9 @@ class PhonopyWorkChain(BasePhonopyWorkChain, ImmigrantMixIn):
                         cls.collect_remote_data,
                     ).else_(
                         cls.create_force_constants,
-                        cls.run_phonopy_locally,
+                        if_(cls.should_run_local_phonopy)(
+                            cls.run_phonopy_locally,
+                        ),
                     ),
                 ),
             ),
@@ -115,6 +117,10 @@ class PhonopyWorkChain(BasePhonopyWorkChain, ImmigrantMixIn):
     def should_run_phonopy(self):
         """Return boolean for outline."""
         return self.inputs.run_phonopy
+
+    def should_run_local_phonopy(self):
+        """Return boolean for outline."""
+        return "mesh" in self.inputs.settings.keys()
 
     def continue_import(self):
         """Return boolen for outline."""

--- a/tests/workflows/test_phonopy.py
+++ b/tests/workflows/test_phonopy.py
@@ -324,6 +324,31 @@ def test_initialize_with_displacements_and_force_sets_input(
 
 
 def test_launch_process_with_dataset_inputs_and_run_phonopy(
+    generate_inputs_phonopy_wc, generate_workchain, generate_settings
+):
+    """Test of PhonopyWorkChain with dataset inputs using NaCl data."""
+    from aiida.engine import launch
+    from aiida.orm import Bool
+
+    inputs = generate_inputs_phonopy_wc()
+    inputs["run_phonopy"] = Bool(True)
+    inputs["remote_phonopy"] = Bool(False)
+    inputs["settings"] = generate_settings(mesh=100)
+    process = generate_workchain("phonoxpy.phonopy", inputs)
+    result, node = launch.run_get_node(process)
+    output_keys = [
+        "band_structure",
+        "total_dos",
+        "force_constants",
+        "phonon_setting_info",
+        "primitive",
+        "supercell",
+        "thermal_properties",
+    ]
+    assert set(list(result)) == set(output_keys)
+
+
+def test_launch_process_with_dataset_inputs_and_run_phonopy_without_mesh(
     generate_inputs_phonopy_wc, generate_workchain
 ):
     """Test of PhonopyWorkChain with dataset inputs using NaCl data."""
@@ -336,13 +361,10 @@ def test_launch_process_with_dataset_inputs_and_run_phonopy(
     process = generate_workchain("phonoxpy.phonopy", inputs)
     result, node = launch.run_get_node(process)
     output_keys = [
-        "band_structure",
-        "total_dos",
         "force_constants",
         "phonon_setting_info",
         "primitive",
         "supercell",
-        "thermal_properties",
     ]
     assert set(list(result)) == set(output_keys)
 
@@ -358,7 +380,7 @@ def test_launch_process_with_dataset_inputs_and_run_phonopy_with_fc_calculator(
     inputs["run_phonopy"] = Bool(True)
     inputs["remote_phonopy"] = Bool(False)
     inputs["settings"] = generate_settings(
-        fc_calculator="alm", fc_calculator_options="cutoff = 5"
+        mesh=100, fc_calculator="alm", fc_calculator_options="cutoff = 5"
     )
     process = generate_workchain("phonoxpy.phonopy", inputs)
     result, node = launch.run_get_node(process)


### PR DESCRIPTION
Changed behaviour of phonopy workchain when `mesh` in `inputs.settings` is unspecified.
Previously `mesh=100` was set as default and this calculates phonon properties, but this PR changes to `mesh` is unspecified for phonopy calculation, which only calculates force constants.