### PR TITLE
Allow force_constants input for phonopy remote calculation

### DIFF
--- a/aiida_phonoxpy/calculations/phonopy.py
+++ b/aiida_phonoxpy/calculations/phonopy.py
@@ -97,9 +97,10 @@ class PhonopyCalculation(BasePhonopyCalculation):
         )
 
         self._internal_retrieve_list = [
-            self._INOUT_FORCE_CONSTANTS,
             self.inputs.metadata.options.output_filename,
         ]
+        if "force_constants" not in self.inputs:
+            self._internal_retrieve_list.append(self._INOUT_FORCE_CONSTANTS)
 
         self._additional_cmd_params = [general_opts + fc_opts]
 

--- a/aiida_phonoxpy/parsers/phono3py.py
+++ b/aiida_phonoxpy/parsers/phono3py.py
@@ -46,7 +46,7 @@ class Phono3pyParser(Parser):
             self.out("version", Str(yaml_dict["phono3py"]["version"]))
 
         for filename in ("fc2.hdf5", "fc3.hdf5"):
-            if filename in filename in filenames_parsed:
+            if filename in filenames_parsed:
                 with output_folder.open(filename, "rb") as handle:
                     output_node = SinglefileData(file=handle, filename=filename)
                     self.out(filename.replace(".hdf5", ""), output_node)

--- a/aiida_phonoxpy/parsers/phonopy.py
+++ b/aiida_phonoxpy/parsers/phonopy.py
@@ -1,13 +1,13 @@
 """Parsers of phonopy output files."""
 from aiida.common.exceptions import NotExistent
 from aiida.engine import ExitCode
-from aiida.orm import Str
+from aiida.orm import Str, SinglefileData
 from aiida.parsers.parser import Parser
 from aiida.plugins import CalculationFactory
 
 from aiida_phonoxpy.common.raw_parsers import (
     parse_band_structure,
-    parse_FORCE_CONSTANTS,
+    # parse_FORCE_CONSTANTS,
     parse_phonopy_yaml,
     parse_projected_dos,
     parse_thermal_properties,
@@ -35,9 +35,13 @@ class PhonopyParser(Parser):
         list_of_files = output_folder.list_object_names()
 
         fc_filename = PhonopyCalculation._INOUT_FORCE_CONSTANTS
+        # if fc_filename in list_of_files:
+        #     with output_folder.open(fc_filename, "rb") as f:
+        #         self.out("force_constants", parse_FORCE_CONSTANTS(f))
         if fc_filename in list_of_files:
-            with output_folder.open(fc_filename, "rb") as f:
-                self.out("force_constants", parse_FORCE_CONSTANTS(f))
+            with output_folder.open(fc_filename, "rb") as handle:
+                output_node = SinglefileData(file=handle, filename=fc_filename)
+                self.out("force_constants", output_node)
 
         projected_dos_filename = PhonopyCalculation._OUTPUT_PROJECTED_DOS
         if projected_dos_filename in list_of_files:

--- a/aiida_phonoxpy/workflows/base.py
+++ b/aiida_phonoxpy/workflows/base.py
@@ -94,7 +94,6 @@ class BasePhonopyWorkChain(WorkChain):
         spec.input("code", valid_type=Code, required=False)
         spec.input("donothing_inputs", valid_type=dict, required=False, non_db=True)
 
-        spec.output("force_constants", valid_type=ArrayData, required=False)
         spec.output("primitive", valid_type=StructureData, required=False)
         spec.output("supercell", valid_type=StructureData, required=False)
         spec.output("displacements", valid_type=ArrayData, required=False)

--- a/aiida_phonoxpy/workflows/phonopy.py
+++ b/aiida_phonoxpy/workflows/phonopy.py
@@ -1,7 +1,7 @@
 """PhonopyWorkChain."""
 
 from aiida.engine import if_, while_
-from aiida.orm import BandsData, Bool, Code, Dict, XyData
+from aiida.orm import BandsData, Bool, Code, Dict, XyData, SinglefileData, ArrayData
 
 from aiida_phonoxpy.calculations.phonopy import PhonopyCalculation
 from aiida_phonoxpy.utils.utils import (
@@ -96,6 +96,10 @@ class PhonopyWorkChain(BasePhonopyWorkChain, ImmigrantMixIn):
                 ),
             ),
             cls.finalize,
+        )
+        # spec.output("force_constants", valid_type=ArrayData, required=False)
+        spec.output(
+            "force_constants", valid_type=(SinglefileData, ArrayData), required=False
         )
         spec.output("thermal_properties", valid_type=XyData, required=False)
         spec.output("band_structure", valid_type=BandsData, required=False)

--- a/tests/calculations/test_phonopy.py
+++ b/tests/calculations/test_phonopy.py
@@ -1,0 +1,120 @@
+"""Test phono3py parser."""
+import pytest
+from aiida.common import AttributeDict
+
+
+@pytest.fixture
+def generate_inputs(generate_structure, generate_nac_params):
+    """Return only those inputs that the parser will expect to be there."""
+
+    def _generate_inputs(metadata=None, with_nac=False):
+        inputs = AttributeDict(
+            {
+                "structure": generate_structure(),
+                "metadata": metadata or {},
+            }
+        )
+        if with_nac:
+            inputs.nac_params = generate_nac_params()
+        return inputs
+
+    return _generate_inputs
+
+
+def test_phonopy(
+    fixture_sandbox,
+    fixture_code,
+    generate_calc_job,
+    generate_inputs,
+    generate_settings,
+):
+    """Test a phonopy calculation."""
+    entry_point_calc_job = "phonoxpy.phonopy"
+
+    inputs = generate_inputs(
+        metadata={"options": {"resources": {"tot_num_mpiprocs": 1}}}
+    )
+    inputs.update(
+        {
+            "settings": generate_settings(),
+            "code": fixture_code(entry_point_calc_job),
+        }
+    )
+
+    calc_info = generate_calc_job(fixture_sandbox, entry_point_calc_job, inputs)
+    assert set(calc_info.retrieve_list) == set(("phonopy.yaml", "force_constants.hdf5"))
+    assert not calc_info.local_copy_list
+    assert set(calc_info.codes_info[0].cmdline_params) == set(
+        (
+            "-c",
+            "--sym-fc",
+            "phonopy_params.yaml.xz",
+            "--writefc",
+            "--writefc-format=hdf5",
+        )
+    )
+
+
+def test_phonopy_fc_calculator(
+    fixture_sandbox,
+    fixture_code,
+    generate_calc_job,
+    generate_inputs,
+    generate_settings,
+):
+    """Test a phonopy calculation."""
+    entry_point_calc_job = "phonoxpy.phonopy"
+
+    inputs = generate_inputs(
+        metadata={"options": {"resources": {"tot_num_mpiprocs": 1}}}
+    )
+    inputs.update(
+        {
+            "settings": generate_settings(fc_calculator="alm"),
+            "code": fixture_code(entry_point_calc_job),
+        }
+    )
+
+    calc_info = generate_calc_job(fixture_sandbox, entry_point_calc_job, inputs)
+    assert set(calc_info.retrieve_list) == set(("phonopy.yaml", "force_constants.hdf5"))
+    assert not calc_info.local_copy_list
+    assert set(calc_info.codes_info[0].cmdline_params) == set(
+        (
+            "-v",
+            "-c",
+            "phonopy_params.yaml.xz",
+            "--writefc",
+            "--writefc-format=hdf5",
+            "--alm",
+        )
+    )
+
+
+def test_phonopy_fc_input(
+    fixture_sandbox,
+    fixture_code,
+    generate_calc_job,
+    generate_inputs,
+    generate_settings,
+    generate_fc_filedata,
+):
+    """Test a phonopy calculation."""
+    entry_point_calc_job = "phonoxpy.phonopy"
+
+    inputs = generate_inputs(
+        metadata={"options": {"resources": {"tot_num_mpiprocs": 1}}}
+    )
+    inputs.update(
+        {
+            "settings": generate_settings(),
+            "code": fixture_code(entry_point_calc_job),
+            "force_constants": generate_fc_filedata(),
+        }
+    )
+
+    calc_info = generate_calc_job(fixture_sandbox, entry_point_calc_job, inputs)
+    assert set(calc_info.retrieve_list) == set(("phonopy.yaml", "force_constants.hdf5"))
+    assert calc_info.local_copy_list[0][2] == "force_constants.hdf5"
+    assert set(calc_info.codes_info[0].cmdline_params) == set(
+        ("-c", "phonopy_params.yaml.xz", "--readfc", "--readfc-format=hdf5")
+    )

--- a/tests/calculations/test_phonopy.py
+++ b/tests/calculations/test_phonopy.py
@@ -113,7 +113,7 @@ def test_phonopy_fc_input(
     )
 
     calc_info = generate_calc_job(fixture_sandbox, entry_point_calc_job, inputs)
-    assert set(calc_info.retrieve_list) == set(("phonopy.yaml", "force_constants.hdf5"))
+    assert set(calc_info.retrieve_list) == set(("phonopy.yaml",))
     assert calc_info.local_copy_list[0][2] == "force_constants.hdf5"
     assert set(calc_info.codes_info[0].cmdline_params) == set(
         ("-c", "phonopy_params.yaml.xz", "--readfc", "--readfc-format=hdf5")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -950,6 +950,28 @@ def generate_nac_params():
 
 
 @pytest.fixture
+def generate_fc_filedata(filepath_tests):
+    """Generate a `SinglefileData` instance with force_constants.hdf5 file."""
+
+    def _generate_fc_filedata(structure_id: str = "NaCl-8"):
+        if structure_id == "NaCl-8":
+            filepath = os.path.join(
+                filepath_tests,
+                "parsers",
+                "fixtures",
+                "phonopy",
+                "default",
+                "force_constants.hdf5",
+            )
+        else:
+            raise KeyError(f'Unknown structure_id="{structure_id}"')
+
+        return SinglefileData(filepath)
+
+    return _generate_fc_filedata
+
+
+@pytest.fixture
 def generate_fc3_filedata(filepath_tests):
     """Generate a `SinglefileData` instance with fc3.hdf5 file."""
 

--- a/tests/parsers/test_phonopy.py
+++ b/tests/parsers/test_phonopy.py
@@ -30,6 +30,8 @@ def test_phonopy_default(
     num_regression,
 ):
     """Test a phonopy calculation."""
+    import h5py
+
     name = "default"
     entry_point_calc_job = "phonoxpy.phonopy"
     entry_point_parser = "phonoxpy.phonopy"
@@ -66,10 +68,19 @@ def test_phonopy_default(
         }
     )
 
-    num_regression.check(
-        {
-            "force_constants": results["force_constants"]
-            .get_array("force_constants")
-            .ravel()
-        }
-    )
+    with results["force_constants"].open(mode="rb") as fc:
+        with h5py.File(fc) as f_fc:
+            num_regression.check(
+                {
+                    "force_constants": f_fc["force_constants"][:].ravel(),
+                }
+            )
+
+    # Old test when force_constants was ArrayData.
+    # num_regression.check(
+    #     {
+    #         "force_constants": results["force_constants"]
+    #         .get_array("force_constants")
+    #         .ravel()
+    #     }
+    # )

--- a/tests/parsers/test_phonopy.py
+++ b/tests/parsers/test_phonopy.py
@@ -5,11 +5,13 @@ from aiida.common import AttributeDict
 
 
 @pytest.fixture
-def generate_inputs(generate_structure, generate_nac_params, generate_settings):
+def generate_inputs(
+    generate_structure, generate_nac_params, generate_settings, generate_fc_filedata
+):
     """Return only those inputs that the parser will expect to be there."""
 
-    def _generate_inputs(metadata=None):
-        return AttributeDict(
+    def _generate_inputs(metadata=None, with_force_constants=False):
+        attr_dict = AttributeDict(
             {
                 "structure": generate_structure(),
                 "settings": generate_settings(),
@@ -17,6 +19,9 @@ def generate_inputs(generate_structure, generate_nac_params, generate_settings):
                 "nac_params": generate_nac_params(),
             }
         )
+        if with_force_constants:
+            attr_dict.force_constants = generate_fc_filedata()
+        return attr_dict
 
     return _generate_inputs
 
@@ -75,12 +80,3 @@ def test_phonopy_default(
                     "force_constants": f_fc["force_constants"][:].ravel(),
                 }
             )
-
-    # Old test when force_constants was ArrayData.
-    # num_regression.check(
-    #     {
-    #         "force_constants": results["force_constants"]
-    #         .get_array("force_constants")
-    #         .ravel()
-    #     }
-    # )


### PR DESCRIPTION
Currently, phonopy workchain can not take force constants as an input. This PR allows to do it.