### PR TITLE
Attempt to support random displacements at finite temperature

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1069,6 +1069,7 @@ def generate_settings():
         mass_variances=None,
         mesh=None,
         number_of_snapshots=None,
+        temperature=None,
         pinv_cutoff=None,
         pinv_method=None,
         pinv_solver=None,
@@ -1107,6 +1108,9 @@ def generate_settings():
 
         if number_of_snapshots is not None:
             settings["number_of_snapshots"] = number_of_snapshots
+
+        if temperature is not None:
+            settings["temperature"] = temperature
 
         if pinv_cutoff is not None:
             settings["pinv_cutoff"] = pinv_cutoff


### PR DESCRIPTION
This is an attempt to support random displacements at finite temperature.
`temperature` tag is supported as written in `settings`, and when this is used with `inputs.force_constants`, random displacements at finite temperature is generated. 
The aim of this implementation is self-consistent harmonic approximation. Currently, this PR requires the latest develop branch of phonopy (9b0107ab16e) since a special method of Phonopy class `ph.random_displacements.treat_imaginary_modes()` is called.